### PR TITLE
fix: typo

### DIFF
--- a/src/model/marc_relators.go
+++ b/src/model/marc_relators.go
@@ -260,7 +260,7 @@ var Relator = map[string]string{
 	"sfx":"special effects provider",
 	"sgd":"stage director",
 	"sgn":"signer",
-	"sht":"spporting host",
+	"sht":"supporting host",
 	"sll":"seller",
 	"sng":"singer",
 	"spk":"speaker",


### PR DESCRIPTION
Found via `codespell -L anc,ths,wit`